### PR TITLE
Add APK diff, patch and AI assistant commands

### DIFF
--- a/jadx-cli/src/main/java/jadx/cli/JadxCLICommands.java
+++ b/jadx-cli/src/main/java/jadx/cli/JadxCLICommands.java
@@ -6,15 +6,21 @@ import java.util.Map;
 import com.beust.jcommander.JCommander;
 
 import jadx.cli.commands.CommandPlugins;
+import jadx.cli.commands.CommandApkDiff;
+import jadx.cli.commands.CommandApkPatch;
+import jadx.cli.commands.CommandAssistant;
 import jadx.cli.commands.ICommand;
 import jadx.core.utils.exceptions.JadxArgsValidateException;
 
 public class JadxCLICommands {
 	private static final Map<String, ICommand> COMMANDS_MAP = new LinkedHashMap<>();
 
-	static {
-		JadxCLICommands.register(new CommandPlugins());
-	}
+       static {
+               JadxCLICommands.register(new CommandPlugins());
+               JadxCLICommands.register(new CommandApkDiff());
+               JadxCLICommands.register(new CommandApkPatch());
+               JadxCLICommands.register(new CommandAssistant());
+       }
 
 	public static void register(ICommand command) {
 		COMMANDS_MAP.put(command.name(), command);

--- a/jadx-cli/src/main/java/jadx/cli/commands/CommandApkDiff.java
+++ b/jadx-cli/src/main/java/jadx/cli/commands/CommandApkDiff.java
@@ -1,0 +1,89 @@
+package jadx.cli.commands;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import jadx.cli.JCommanderWrapper;
+import jadx.zip.ZipReader;
+
+@Parameters(commandDescription = "compare two apk files")
+public class CommandApkDiff implements ICommand {
+    @Parameter(names = {"--old"}, description = "old apk", required = true)
+    private Path oldApk;
+
+    @Parameter(names = {"--new"}, description = "new apk", required = true)
+    private Path newApk;
+
+    @Parameter(names = {"-h", "--help"}, help = true, description = "print this help")
+    private boolean help;
+
+    @Override
+    public String name() {
+        return "apkdiff";
+    }
+
+    @Override
+    public void process(JCommanderWrapper jcw, JCommander sub) {
+        if (help) {
+            jcw.printUsage(sub);
+            return;
+        }
+        try {
+            Map<String, String> oldMap = buildHashMap(oldApk);
+            Map<String, String> newMap = buildHashMap(newApk);
+            Set<String> names = new HashSet<>();
+            names.addAll(oldMap.keySet());
+            names.addAll(newMap.keySet());
+            for (String name : names) {
+                String oldMd5 = oldMap.get(name);
+                String newMd5 = newMap.get(name);
+                if (oldMd5 == null) {
+                    System.out.println("ADDED " + name);
+                } else if (newMd5 == null) {
+                    System.out.println("REMOVED " + name);
+                } else if (!oldMd5.equals(newMd5)) {
+                    System.out.println("CHANGED " + name);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("APK diff failed", e);
+        }
+    }
+
+    private Map<String, String> buildHashMap(Path apk) throws Exception {
+        Map<String, String> map = new HashMap<>();
+        ZipReader reader = new ZipReader();
+        reader.readEntries(apk.toFile(), (entry, in) -> {
+            try {
+                map.put(entry.getName(), md5(in));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return map;
+    }
+
+    private static String md5(InputStream in) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("MD5");
+        byte[] buf = new byte[8192];
+        int r;
+        while ((r = in.read(buf)) != -1) {
+            digest.update(buf, 0, r);
+        }
+        byte[] arr = digest.digest();
+        StringBuilder sb = new StringBuilder(arr.length * 2);
+        for (byte b : arr) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/jadx-cli/src/main/java/jadx/cli/commands/CommandApkPatch.java
+++ b/jadx-cli/src/main/java/jadx/cli/commands/CommandApkPatch.java
@@ -1,0 +1,159 @@
+package jadx.cli.commands;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import jadx.cli.JCommanderWrapper;
+import jadx.zip.ZipReader;
+
+@Parameters(commandDescription = "apply patch from old modified apk to new apk")
+public class CommandApkPatch implements ICommand {
+    @Parameter(names = {"--old"}, description = "old original apk", required = true)
+    private Path oldApk;
+
+    @Parameter(names = {"--old-mod"}, description = "old modified apk", required = true)
+    private Path oldModApk;
+
+    @Parameter(names = {"--new"}, description = "new original apk", required = true)
+    private Path newApk;
+
+    @Parameter(names = {"--out"}, description = "output patched apk", required = true)
+    private Path outApk;
+
+    @Parameter(names = {"-h", "--help"}, help = true, description = "print this help")
+    private boolean help;
+
+    @Override
+    public String name() {
+        return "apkpatch";
+    }
+
+    @Override
+    public void process(JCommanderWrapper jcw, JCommander sub) {
+        if (help) {
+            jcw.printUsage(sub);
+            return;
+        }
+        try {
+            Map<String, String> oldMap = buildHashMap(oldApk);
+            Map<String, byte[]> modMap = loadEntries(oldModApk);
+            Set<String> changed = new HashSet<>();
+            for (Map.Entry<String, byte[]> e : modMap.entrySet()) {
+                String name = e.getKey();
+                byte[] data = e.getValue();
+                String orig = oldMap.get(name);
+                if (orig == null || !orig.equals(md5(data))) {
+                    changed.add(name);
+                }
+            }
+            // build patched apk
+            try (ZipInputStream zin = new ZipInputStream(Files.newInputStream(newApk));
+                 ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(outApk))) {
+                ZipEntry ent;
+                Set<String> processed = new HashSet<>();
+                while ((ent = zin.getNextEntry()) != null) {
+                    if (changed.contains(ent.getName())) {
+                        byte[] data = modMap.get(ent.getName());
+                        if (data != null) {
+                            zout.putNextEntry(new ZipEntry(ent.getName()));
+                            zout.write(data);
+                            processed.add(ent.getName());
+                        }
+                    } else if (!modMap.containsKey(ent.getName()) || oldMap.containsKey(ent.getName())) {
+                        zout.putNextEntry(new ZipEntry(ent.getName()));
+                        copyStream(zin, zout);
+                    }
+                }
+                for (String name : changed) {
+                    if (!processed.contains(name)) {
+                        zout.putNextEntry(new ZipEntry(name));
+                        zout.write(modMap.get(name));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("APK patch failed", e);
+        }
+    }
+
+    private Map<String, byte[]> loadEntries(Path apk) throws Exception {
+        Map<String, byte[]> map = new HashMap<>();
+        ZipReader reader = new ZipReader();
+        reader.readEntries(apk.toFile(), (entry, in) -> {
+            try {
+                map.put(entry.getName(), readAllBytes(in));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return map;
+    }
+
+    private Map<String, String> buildHashMap(Path apk) throws Exception {
+        Map<String, String> map = new HashMap<>();
+        ZipReader reader = new ZipReader();
+        reader.readEntries(apk.toFile(), (entry, in) -> {
+            try {
+                map.put(entry.getName(), md5(in));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return map;
+    }
+
+    private static String md5(byte[] data) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("MD5");
+        digest.update(data);
+        byte[] arr = digest.digest();
+        StringBuilder sb = new StringBuilder(arr.length * 2);
+        for (byte b : arr) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private static String md5(InputStream in) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("MD5");
+        byte[] buf = new byte[8192];
+        int r;
+        while ((r = in.read(buf)) != -1) {
+            digest.update(buf, 0, r);
+        }
+        byte[] arr = digest.digest();
+        StringBuilder sb = new StringBuilder(arr.length * 2);
+        for (byte b : arr) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private static byte[] readAllBytes(InputStream in) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        copyStream(in, out);
+        return out.toByteArray();
+    }
+
+    private static void copyStream(InputStream in, OutputStream out) throws Exception {
+        byte[] buf = new byte[8192];
+        int r;
+        while ((r = in.read(buf)) != -1) {
+            out.write(buf, 0, r);
+        }
+    }
+}

--- a/jadx-cli/src/main/java/jadx/cli/commands/CommandAssistant.java
+++ b/jadx-cli/src/main/java/jadx/cli/commands/CommandAssistant.java
@@ -1,0 +1,65 @@
+package jadx.cli.commands;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import jadx.cli.JCommanderWrapper;
+import jadx.api.plugins.utils.CommonFileUtils;
+
+@Parameters(commandDescription = "ask AI assistant (OpenAI API)")
+public class CommandAssistant implements ICommand {
+    @Parameter(names = {"-q", "--question"}, description = "question text")
+    private String question;
+
+    @Parameter(names = {"--model"}, description = "openai model id")
+    private String model = "gpt-3.5-turbo";
+
+    @Parameter(names = {"-h", "--help"}, help = true, description = "print this help")
+    private boolean help;
+
+    @Override
+    public String name() {
+        return "assistant";
+    }
+
+    @Override
+    public void process(JCommanderWrapper jcw, JCommander sub) {
+        if (help || question == null) {
+            jcw.printUsage(sub);
+            return;
+        }
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isEmpty()) {
+            System.out.println("OPENAI_API_KEY environment variable not set");
+            return;
+        }
+        try {
+            HttpURLConnection con = (HttpURLConnection) URI.create("https://api.openai.com/v1/chat/completions").toURL().openConnection();
+            con.setRequestMethod("POST");
+            con.setRequestProperty("Authorization", "Bearer " + apiKey);
+            con.setRequestProperty("Content-Type", "application/json");
+            con.setDoOutput(true);
+            String payload = String.format("{\"model\":\"%s\",\"messages\":[{\"role\":\"user\",\"content\":%s}]}", model, quote(question));
+            try (OutputStream out = con.getOutputStream()) {
+                out.write(payload.getBytes(StandardCharsets.UTF_8));
+            }
+            int code = con.getResponseCode();
+            try (var in = code >= 200 && code < 300 ? con.getInputStream() : con.getErrorStream()) {
+                String response = new String(CommonFileUtils.loadBytes(in), StandardCharsets.UTF_8);
+                System.out.println(response);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("AI request failed", e);
+        }
+    }
+
+    private static String quote(String str) {
+        return '"' + str.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+}


### PR DESCRIPTION
## Summary
- add `apkdiff` command to compare two APKs
- add `apkpatch` command to patch a new APK using old and modified ones
- add experimental `assistant` command to query OpenAI
- register new commands in `JadxCLICommands`

## Testing
- `./gradlew :jadx-cli:assemble`
- `./gradlew :jadx-cli:test`


------
https://chatgpt.com/codex/tasks/task_e_6855a082da808329a4ac8645b8de3050