### PR TITLE
Add close dialog translations

### DIFF
--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -144,6 +144,7 @@ common_dialog.add=Hinzufügen
 common_dialog.update=Aktualisieren
 common_dialog.remove=Entfernen
 common_dialog.reset=Zurücksetzen
+common_dialog.close=Schließen
 
 file_dialog.supported_files=Unterstützte Dateien
 file_dialog.load_dir_title=Verzeichnis laden

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -147,6 +147,7 @@ common_dialog.add=Add
 common_dialog.update=Update
 common_dialog.remove=Remove
 common_dialog.reset=Reset
+common_dialog.close=Close
 
 file_dialog.supported_files=Supported files
 file_dialog.load_dir_title=Load directory

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -144,6 +144,7 @@ nav.forward=Adelante
 #common_dialog.update=Update
 #common_dialog.remove=Remove
 #common_dialog.reset=Reset
+common_dialog.close=Cerrar
 
 #file_dialog.supported_files=Supported files
 #file_dialog.load_dir_title=Load directory

--- a/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
@@ -144,6 +144,7 @@ common_dialog.add=Tambah
 common_dialog.update=Perbarui
 common_dialog.remove=Hapus
 common_dialog.reset=Reset
+common_dialog.close=Tutup
 
 file_dialog.supported_files=Berkas yang didukung
 file_dialog.load_dir_title=Muat direktori

--- a/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
@@ -144,6 +144,7 @@ common_dialog.add=추가
 common_dialog.update=업데이트
 common_dialog.remove=삭제
 #common_dialog.reset=Reset
+common_dialog.close=닫기
 
 file_dialog.supported_files=지원되는 파일
 file_dialog.load_dir_title=디렉토리 불러오기

--- a/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
@@ -144,6 +144,7 @@ common_dialog.add=Adicionar
 common_dialog.update=Atualizar
 common_dialog.remove=Remover
 #common_dialog.reset=Reset
+common_dialog.close=Fechar
 
 file_dialog.supported_files=Arquivos suportados
 file_dialog.load_dir_title=Carregar diretório

--- a/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
@@ -147,6 +147,7 @@ common_dialog.add=Добавить
 common_dialog.update=Обновить
 common_dialog.remove=Убрать
 common_dialog.reset=Сброс
+common_dialog.close=Закрыть
 
 file_dialog.supported_files=Поддерж. файлы
 file_dialog.load_dir_title=Импортировать папку

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -144,6 +144,7 @@ common_dialog.add=添加
 common_dialog.update=更新
 common_dialog.remove=移除
 common_dialog.reset=重置
+common_dialog.close=关闭
 
 file_dialog.supported_files=支持的文件
 file_dialog.load_dir_title=加载目录

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
@@ -144,6 +144,7 @@ common_dialog.add=新增
 common_dialog.update=更新
 common_dialog.remove=移除
 common_dialog.reset=重設
+common_dialog.close=關閉
 
 file_dialog.supported_files=支援的檔案
 file_dialog.load_dir_title=載入目錄


### PR DESCRIPTION
## Summary
- translate the common close button for various locales
- use `common_dialog.close` label with `NLS.str()` to avoid missing key

## Testing
- `./gradlew test --no-daemon` *(fails: daemon terminated unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_6855d3580d1c832994cd1e303fab65a8