### PR TITLE
Add CLI command tests

### DIFF
--- a/jadx-cli/src/test/java/jadx/cli/commands/CommandApkDiffTest.java
+++ b/jadx-cli/src/test/java/jadx/cli/commands/CommandApkDiffTest.java
@@ -1,0 +1,56 @@
+package jadx.cli.commands;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import com.beust.jcommander.JCommander;
+
+import jadx.cli.JadxCLIArgs;
+import jadx.cli.JCommanderWrapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommandApkDiffTest {
+
+    @TempDir
+    Path dir;
+
+    private Path createZip(Path path, String name, String content) throws Exception {
+        try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(path))) {
+            zout.putNextEntry(new ZipEntry(name));
+            zout.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+        return path;
+    }
+
+    @Test
+    public void testApkDiff() throws Exception {
+        Path oldZip = createZip(dir.resolve("old.zip"), "a.txt", "1");
+        Path newZip = createZip(dir.resolve("new.zip"), "a.txt", "2");
+
+        CommandApkDiff cmd = new CommandApkDiff();
+        JCommander jc = JCommander.newBuilder().addCommand(cmd.name(), cmd).build();
+        jc.parse(cmd.name(), "--old", oldZip.toString(), "--new", newZip.toString());
+        JCommander sub = jc.getCommands().get(cmd.name());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream old = System.out;
+        System.setOut(new PrintStream(out));
+        try {
+            cmd.process(new JCommanderWrapper(new JadxCLIArgs()), sub);
+        } finally {
+            System.setOut(old);
+        }
+
+        String result = out.toString(StandardCharsets.UTF_8);
+        assertThat(result.trim()).contains("CHANGED a.txt");
+    }
+}

--- a/jadx-cli/src/test/java/jadx/cli/commands/CommandApkPatchTest.java
+++ b/jadx-cli/src/test/java/jadx/cli/commands/CommandApkPatchTest.java
@@ -1,0 +1,80 @@
+package jadx.cli.commands;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import com.beust.jcommander.JCommander;
+
+import jadx.cli.JadxCLIArgs;
+import jadx.cli.JCommanderWrapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommandApkPatchTest {
+
+    @TempDir
+    Path dir;
+
+    private Path createZip(Path path, String name, String content) throws Exception {
+        try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(path))) {
+            zout.putNextEntry(new ZipEntry(name));
+            zout.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+        return path;
+    }
+
+    @Test
+    public void testApkPatch() throws Exception {
+        Path oldZip = createZip(dir.resolve("old.zip"), "a.txt", "1");
+        Path oldModZip = createZip(dir.resolve("oldmod.zip"), "a.txt", "2");
+        Path newZip = dir.resolve("new.zip");
+        try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(newZip))) {
+            zout.putNextEntry(new ZipEntry("a.txt"));
+            zout.write("1".getBytes(StandardCharsets.UTF_8));
+            zout.putNextEntry(new ZipEntry("b.txt"));
+            zout.write("b".getBytes(StandardCharsets.UTF_8));
+        }
+        Path outZip = dir.resolve("out.zip");
+
+        CommandApkPatch cmd = new CommandApkPatch();
+        JCommander jc = JCommander.newBuilder().addCommand(cmd.name(), cmd).build();
+        jc.parse(cmd.name(), "--old", oldZip.toString(), "--old-mod", oldModZip.toString(),
+                "--new", newZip.toString(), "--out", outZip.toString());
+        JCommander sub = jc.getCommands().get(cmd.name());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream oldOut = System.out;
+        System.setOut(new PrintStream(out));
+        try {
+            cmd.process(new JCommanderWrapper(new JadxCLIArgs()), sub);
+        } finally {
+            System.setOut(oldOut);
+        }
+
+        try (ZipInputStream zin = new ZipInputStream(Files.newInputStream(outZip))) {
+            ZipEntry ent;
+            String aContent = null;
+            String bContent = null;
+            while ((ent = zin.getNextEntry()) != null) {
+                ByteArrayOutputStream buf = new ByteArrayOutputStream();
+                zin.transferTo(buf);
+                if (ent.getName().equals("a.txt")) {
+                    aContent = buf.toString(StandardCharsets.UTF_8);
+                } else if (ent.getName().equals("b.txt")) {
+                    bContent = buf.toString(StandardCharsets.UTF_8);
+                }
+            }
+            assertThat(aContent).isEqualTo("2");
+            assertThat(bContent).isEqualTo("b");
+        }
+    }
+}

--- a/jadx-cli/src/test/java/jadx/cli/commands/CommandAssistantTest.java
+++ b/jadx-cli/src/test/java/jadx/cli/commands/CommandAssistantTest.java
@@ -1,0 +1,126 @@
+package jadx.cli.commands;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import com.beust.jcommander.JCommander;
+
+import jadx.cli.JadxCLIArgs;
+import jadx.cli.JCommanderWrapper;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommandAssistantTest {
+
+    static class MockHttpURLConnection extends HttpURLConnection {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int responseCode = 200;
+        String response = "{}";
+
+        MockHttpURLConnection(URL u) { super(u); }
+        @Override public void disconnect() {}
+        @Override public boolean usingProxy() { return false; }
+        @Override public void connect() {}
+        @Override public OutputStream getOutputStream() { return out; }
+        @Override public InputStream getInputStream() { return new ByteArrayInputStream(response.getBytes(StandardCharsets.UTF_8)); }
+        @Override public InputStream getErrorStream() { return getInputStream(); }
+        @Override public int getResponseCode() { return responseCode; }
+    }
+
+    private static MockHttpURLConnection lastCon;
+
+    @BeforeAll
+    static void installFactory() {
+        try {
+            URL.setURLStreamHandlerFactory(new URLStreamHandlerFactory() {
+                @Override
+                public URLStreamHandler createURLStreamHandler(String protocol) {
+                    if ("https".equals(protocol)) {
+                        return new URLStreamHandler() {
+                            @Override
+                            protected URLConnection openConnection(URL u) {
+                                lastCon = new MockHttpURLConnection(u);
+                                return lastCon;
+                            }
+                        };
+                    }
+                    return null;
+                }
+            });
+        } catch (Error ignore) {
+        }
+    }
+
+    @Test
+    public void testRequestFormatting() throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                "-cp", System.getProperty("java.class.path"),
+                Runner.class.getName());
+        pb.environment().put("OPENAI_API_KEY", "token");
+        Process proc = pb.start();
+        byte[] out = proc.getInputStream().readAllBytes();
+        proc.getErrorStream().transferTo(System.err);
+        int code = proc.waitFor();
+        assertThat(code).isEqualTo(0);
+        String res = new String(out, StandardCharsets.UTF_8);
+        assertThat(res).contains("BODY:");
+        assertThat(res).contains("\"content\":\"hi\"");
+        assertThat(res).contains("AUTH:Bearer token");
+    }
+
+    public static class Runner {
+        public static void main(String[] args) throws Exception {
+            // install handler in subprocess
+            try {
+                URL.setURLStreamHandlerFactory(new URLStreamHandlerFactory() {
+                    @Override
+                    public URLStreamHandler createURLStreamHandler(String protocol) {
+                        if ("https".equals(protocol)) {
+                            return new URLStreamHandler() {
+                                @Override
+                                protected URLConnection openConnection(URL u) {
+                                    lastCon = new MockHttpURLConnection(u);
+                                    return lastCon;
+                                }
+                            };
+                        }
+                        return null;
+                    }
+                });
+            } catch (Error ignore) {
+            }
+            CommandAssistant cmd = new CommandAssistant();
+            JCommander jc = JCommander.newBuilder().addCommand(cmd.name(), cmd).build();
+            jc.parse(cmd.name(), "-q", "hi");
+            JCommander sub = jc.getCommands().get(cmd.name());
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            PrintStream old = System.out;
+            System.setOut(new PrintStream(bout));
+            try {
+                cmd.process(new JCommanderWrapper(new JadxCLIArgs()), sub);
+            } finally {
+                System.setOut(old);
+            }
+            if (lastCon != null) {
+                String body = lastCon.out.toString(StandardCharsets.UTF_8);
+                String auth = lastCon.getRequestProperty("Authorization");
+                System.out.println("BODY:" + body);
+                System.out.println("AUTH:" + auth);
+            }
+        }
+    }
+}

--- a/jadx-cli/src/test/java/jadx/cli/commands/CommandsRegistrationTest.java
+++ b/jadx-cli/src/test/java/jadx/cli/commands/CommandsRegistrationTest.java
@@ -1,0 +1,24 @@
+package jadx.cli.commands;
+
+import com.beust.jcommander.JCommander;
+
+import jadx.cli.JadxCLIArgs;
+import jadx.cli.JadxCLICommands;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommandsRegistrationTest {
+
+    @Test
+    public void testCommandsAreRegistered() {
+        JCommander.Builder builder = JCommander.newBuilder();
+        builder.addObject(new JadxCLIArgs());
+        JadxCLICommands.append(builder);
+        JCommander jc = builder.build();
+
+        assertThat(jc.getCommands().keySet())
+                .contains("plugins", "apkdiff", "apkpatch", "assistant");
+    }
+}


### PR DESCRIPTION
## Summary
- add test for command registration
- test diff functionality via simple zip files
- verify patch command outputs patched data
- mock OpenAI assistant request via subprocess

## Testing
- `./gradlew :jadx-cli:test --no-build-cache`

------
https://chatgpt.com/codex/tasks/task_e_6855d78044ac83299b200ba708747390