### PR TITLE
Add add command to CLI

### DIFF
--- a/jadx-cli/build.gradle.kts
+++ b/jadx-cli/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-	id("jadx-java")
-	id("jadx-library")
-	id("application")
+    id("jadx-kotlin")
+    id("jadx-library")
+    id("application")
 
 	// use shadow only for application scripts, jar will be copied from jadx-gui
 	id("com.gradleup.shadow") version "8.3.6"

--- a/jadx-cli/src/main/java/jadx/cli/JadxCLICommands.java
+++ b/jadx-cli/src/main/java/jadx/cli/JadxCLICommands.java
@@ -9,6 +9,7 @@ import jadx.cli.commands.CommandPlugins;
 import jadx.cli.commands.CommandApkDiff;
 import jadx.cli.commands.CommandApkPatch;
 import jadx.cli.commands.CommandAssistant;
+import jadx.cli.commands.CommandAdd;
 import jadx.cli.commands.ICommand;
 import jadx.core.utils.exceptions.JadxArgsValidateException;
 
@@ -20,6 +21,7 @@ public class JadxCLICommands {
                JadxCLICommands.register(new CommandApkDiff());
                JadxCLICommands.register(new CommandApkPatch());
                JadxCLICommands.register(new CommandAssistant());
+               JadxCLICommands.register(new CommandAdd());
        }
 
 	public static void register(ICommand command) {

--- a/jadx-cli/src/main/kotlin/jadx/cli/commands/CommandAdd.kt
+++ b/jadx-cli/src/main/kotlin/jadx/cli/commands/CommandAdd.kt
@@ -1,0 +1,31 @@
+package jadx.cli.commands
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.Parameter
+import com.beust.jcommander.Parameters
+import jadx.cli.JCommanderWrapper
+
+@Parameters(commandDescription = "add two numbers")
+class CommandAdd : ICommand {
+    @Parameter(names = ["--a"], description = "first number", required = true)
+    private var a: Int = 0
+
+    @Parameter(names = ["--b"], description = "second number", required = true)
+    private var b: Int = 0
+
+    @Parameter(names = ["-h", "--help"], help = true, description = "print this help")
+    private var help = false
+
+    override fun name(): String {
+        return "add"
+    }
+
+    override fun process(jcw: JCommanderWrapper, sub: JCommander) {
+        if (help) {
+            jcw.printUsage(sub)
+            return
+        }
+        val sum = a + b
+        println(sum)
+    }
+}

--- a/jadx-cli/src/test/java/jadx/cli/AddCommandTest.java
+++ b/jadx-cli/src/test/java/jadx/cli/AddCommandTest.java
@@ -1,0 +1,24 @@
+package jadx.cli;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AddCommandTest {
+    @Test
+    public void testAddCommand() {
+        PrintStream oldOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+        try {
+            int result = JadxCLI.execute(new String[]{"add", "--a", "2", "--b", "3"});
+            assertThat(result).isEqualTo(0);
+        } finally {
+            System.setOut(oldOut);
+        }
+        assertThat(out.toString().trim()).isEqualTo("5");
+    }
+}


### PR DESCRIPTION
## Summary
- add `CommandAdd` for adding two numbers
- wire up `CommandAdd` in the command registry
- enable kotlin for the CLI module
- test the new command

## Testing
- `./gradlew :jadx-cli:test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6855d7816b7c8329852d4548af47c71f