### PR TITLE
Unify README code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can use jadx in your java projects, check details on [wiki page](https://git
 
 ### Build from source
 JDK 11 or higher must be installed:
-```
+```bash
 git clone https://github.com/skylot/jadx.git
 cd jadx
 ./gradlew dist
@@ -85,7 +85,7 @@ Scripts for run jadx will be placed in `build/jadx/bin`
 and also packed to `build/jadx-<version>.zip`
 
 ### Usage
-```
+```bash
 jadx[-gui] [command] [options] <input files> (.apk, .dex, .jar, .class, .smali, .zip, .aar, .arsc, .aab, .xapk, .apkm, .jadx.kts)
 commands (use '<command> --help' for command options):
   plugins	  - manage jadx plugins
@@ -214,7 +214,7 @@ Examples:
 These options also work in jadx-gui running from command line and override options from preferences' dialog
 
 Usage for `plugins` command
-```
+```bash
 usage: plugins [options]
 options:
   -i, --install <locationId>      - install plugin with locationId

--- a/config/jflex/README.md
+++ b/config/jflex/README.md
@@ -1,5 +1,5 @@
 Refer to the following instructions to modify and use to generate SmaliTokenMarker
 
-```shell
+```bash
 jflex SmaliTokenMaker.flex --skel skeleton.default
 ```


### PR DESCRIPTION
## Summary
- ensure README.md code blocks use `bash` markers
- update jflex README to use the same syntax

## Testing
- `./gradlew --version`
- `./gradlew test --no-daemon` *(fails: build process was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6855d7afa2dc8329aaaa9269812e0267